### PR TITLE
Enable musllinux builds

### DIFF
--- a/.github/workflows/wheels-test.yml
+++ b/.github/workflows/wheels-test.yml
@@ -24,7 +24,7 @@ jobs:
         maturin-version: "v0.13.0"
         target: x86_64-unknown-linux-musl
         manylinux: musllinux_1_1
-        container: off
+        # container: off
         command: build
         args: --release -o dist --find-interpreter --manifest-path crates/stringmetrics_py/Cargo.toml
     - name: Upload wheels

--- a/.github/workflows/wheels-test.yml
+++ b/.github/workflows/wheels-test.yml
@@ -26,7 +26,7 @@ jobs:
         manylinux: musllinux_1_1
         # container: off
         command: build
-        args: --release -o dist --find-interpreter --manifest-path crates/stringmetrics_py/Cargo.toml
+        args: --release -o dist -i 3.7 3.8 3.9 3.10 --manifest-path crates/stringmetrics_py/Cargo.toml
     - name: Upload wheels
       uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/wheels-test.yml
+++ b/.github/workflows/wheels-test.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Build musl wheels
       uses: messense/maturin-action@v1
       with:
-        maturin-version: "v0.13.0"
+        # maturin-version: "v0.13.0"
         target: x86_64-unknown-linux-musl
         manylinux: musllinux_1_1
         # container: off

--- a/.github/workflows/wheels-test.yml
+++ b/.github/workflows/wheels-test.yml
@@ -11,14 +11,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - name: Build Linux Wheels
+    - name: Build libc wheels
       uses: messense/maturin-action@v1
       with:
         manylinux: auto
         command: build
         # container default is manylinux
         args: --release -o dist --manifest-path crates/stringmetrics_py/Cargo.toml
-    - uses: messense/maturin-action@v1
+    - name: Build musl wheels
+      uses: messense/maturin-action@v1
       with:
         maturin-version: "v0.13.0"
         target: x86_64-unknown-linux-musl

--- a/.github/workflows/wheels-test.yml
+++ b/.github/workflows/wheels-test.yml
@@ -21,10 +21,8 @@ jobs:
     - name: Build musl wheels
       uses: messense/maturin-action@v1
       with:
-        # maturin-version: "v0.13.0"
         target: x86_64-unknown-linux-musl
         manylinux: musllinux_1_1
-        # container: off
         command: build
         args: --release -o dist -i 3.7 3.8 3.9 3.10 --manifest-path crates/stringmetrics_py/Cargo.toml
     - name: Upload wheels

--- a/.github/workflows/wheels-test.yml
+++ b/.github/workflows/wheels-test.yml
@@ -11,16 +11,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - uses: messense/maturin-action@v1
+    - name: Build Linux Wheels
+      uses: messense/maturin-action@v1
       with:
         manylinux: auto
         command: build
+        # container default is manylinux
         args: --release -o dist --manifest-path crates/stringmetrics_py/Cargo.toml
     - uses: messense/maturin-action@v1
       with:
         maturin-version: "v0.13.0"
         target: x86_64-unknown-linux-musl
         manylinux: musllinux_1_1
+        container: off
         command: build
         args: --release -o dist --find-interpreter --manifest-path crates/stringmetrics_py/Cargo.toml
     - name: Upload wheels

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -10,19 +10,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - uses: messense/maturin-action@v1
+    - name: Build libc wheels
+      uses: messense/maturin-action@v1
       with:
         manylinux: auto
         command: build
+        # container default is manylinux
         args: --release -o dist --manifest-path crates/stringmetrics_py/Cargo.toml
-    # NOTE: Seems to only build musl wheels for cpython 3.8
-    - uses: messense/maturin-action@v1
+    - name: Build musl wheels
+      uses: messense/maturin-action@v1
       with:
-        maturin-version: "v0.13.0"
         target: x86_64-unknown-linux-musl
         manylinux: musllinux_1_1
         command: build
-        args: --release -o dist --find-interpreter --manifest-path crates/stringmetrics_py/Cargo.toml
+        args: --release -o dist -i 3.7 3.8 3.9 3.10 --manifest-path crates/stringmetrics_py/Cargo.toml
     - name: Upload wheels
       uses: actions/upload-artifact@v2
       with:


### PR DESCRIPTION
Unable to get musl to build for anything other than 3.8

Issue here https://github.com/messense/maturin-action/issues/56